### PR TITLE
画面サイズを800x600に変更し、動的サイズ計算機能を実装

### DIFF
--- a/bird-and-beans/index.html
+++ b/bird-and-beans/index.html
@@ -18,7 +18,7 @@
           <span id="high-score" class="score-value">0</span>
         </div>
       </div>
-      <canvas id="game-canvas" width="1280" height="720"></canvas>
+      <canvas id="game-canvas" width="800" height="600"></canvas>
       <div id="game-over" class="game-over hidden">
         <h2>ゲームオーバー</h2>
         <p>スコア: <span id="final-score">0</span></p>

--- a/bird-and-beans/js/audio.js
+++ b/bird-and-beans/js/audio.js
@@ -1,4 +1,4 @@
-import { AUDIO_GAIN, AUDIO_FADE_TIME, AUDIO_FREQUENCIES, AUDIO_DURATIONS, AUDIO_TYPES } from './constants.js';
+import { AUDIO_GAIN, AUDIO_FADE_TIME, AUDIO_FREQUENCIES, AUDIO_DURATIONS, AUDIO_TYPES } from './config.js';
 
 export class AudioManager {
   constructor() {

--- a/bird-and-beans/js/bean.js
+++ b/bird-and-beans/js/bean.js
@@ -13,8 +13,23 @@ import {
   SPAWN_INTERVAL_DECREASE_RATE,
   SPEED_INCREASE_RATE,
   DIFFICULTY_INCREASE_FRAMES,
-  calculateScoreZones,
+  GROUND_BLOCK_COUNT,
 } from './constants.js';
+
+// スコアゾーンの計算
+const calculateScoreZones = (canvasWidth, canvasHeight) => {
+  const blockHeight = canvasWidth / GROUND_BLOCK_COUNT;
+  const remainingHeight = canvasHeight - blockHeight * 2;
+  const zoneHeight = remainingHeight / 5;
+
+  return [
+    { maxHeight: blockHeight + zoneHeight, score: 1000 }, // 最上部ゾーン
+    { maxHeight: blockHeight + zoneHeight * 2, score: 300 }, // ゾーン2
+    { maxHeight: blockHeight + zoneHeight * 3, score: 100 }, // ゾーン3
+    { maxHeight: blockHeight + zoneHeight * 4, score: 50 }, // ゾーン4
+    { maxHeight: Infinity, score: 10 }, // ゾーン5（最下部）
+  ];
+};
 
 export class Bean {
   constructor(x, y, type = 'normal') {

--- a/bird-and-beans/js/bean.js
+++ b/bird-and-beans/js/bean.js
@@ -6,13 +6,14 @@ import {
   BEAN_SPAWN_MARGIN,
   BEAN_SPAWN_PROBABILITY,
   CANVAS_HEIGHT,
+  CANVAS_WIDTH,
   COLORS,
   INITIAL_SPAWN_INTERVAL,
   MIN_SPAWN_INTERVAL,
   SPAWN_INTERVAL_DECREASE_RATE,
   SPEED_INCREASE_RATE,
   DIFFICULTY_INCREASE_FRAMES,
-  SCORE_ZONES,
+  calculateScoreZones,
 } from './constants.js';
 
 export class Bean {
@@ -55,13 +56,14 @@ export class Bean {
   }
 
   getScore(catchY) {
-    for (const zone of SCORE_ZONES) {
+    const scoreZones = calculateScoreZones(CANVAS_WIDTH, CANVAS_HEIGHT);
+    for (const zone of scoreZones) {
       if (catchY < zone.maxHeight) {
         return zone.score;
       }
     }
     // これは実際には到達しないはず（最後のゾーンがInfinity）
-    return SCORE_ZONES[SCORE_ZONES.length - 1].score;
+    return scoreZones[scoreZones.length - 1].score;
   }
 }
 

--- a/bird-and-beans/js/bean.js
+++ b/bird-and-beans/js/bean.js
@@ -1,6 +1,4 @@
 import {
-  BEAN_WIDTH,
-  BEAN_HEIGHT,
   BEAN_BASE_SPEED,
   BEAN_FLASH_INTERVAL,
   BEAN_SPAWN_MARGIN,
@@ -14,7 +12,8 @@ import {
   SPEED_INCREASE_RATE,
   DIFFICULTY_INCREASE_FRAMES,
   GROUND_BLOCK_COUNT,
-} from './constants.js';
+  calculateDimensions,
+} from './config.js';
 
 // スコアゾーンの計算
 const calculateScoreZones = (canvasWidth, canvasHeight) => {
@@ -35,8 +34,9 @@ export class Bean {
   constructor(x, y, type = 'normal') {
     this.x = x;
     this.y = y;
-    this.width = BEAN_WIDTH;
-    this.height = BEAN_HEIGHT;
+    const dimensions = calculateDimensions();
+    this.width = dimensions.beanWidth;
+    this.height = dimensions.beanHeight;
     this.type = type; // 'normal', 'white', 'flashing'
     this.speed = BEAN_BASE_SPEED;
     this.active = true;
@@ -136,7 +136,8 @@ export class BeanManager {
   }
 
   getRandomSpawnX() {
-    return Math.random() * (this.canvasWidth - BEAN_WIDTH);
+    const dimensions = calculateDimensions();
+    return Math.random() * (this.canvasWidth - dimensions.beanWidth);
   }
 
   getRandomBeanType() {

--- a/bird-and-beans/js/config.js
+++ b/bird-and-beans/js/config.js
@@ -3,7 +3,7 @@ export const CANVAS_WIDTH = 800;
 export const CANVAS_HEIGHT = 600;
 
 // プレイヤー関連
-export const PLAYER_SPEED = 10;
+export const PLAYER_SPEED = 10 / 3; // 1/3に調整
 export const PLAYER_GROUND_MARGIN = 10;
 export const PLAYER_ANIMATION_INTERVAL = 200; // ミリ秒単位
 export const PLAYER_IMAGE_DEFAULT = 'assets/bird_default.png';
@@ -11,14 +11,14 @@ export const PLAYER_IMAGE_WALK = 'assets/bird_walk.png';
 
 // 舌関連
 export const TONGUE_MAX_LENGTH = 700; // 画面サイズ800x600に合わせて調整
-export const TONGUE_EXTEND_SPEED = 30;
+export const TONGUE_EXTEND_SPEED = 30 / 2; // 1/2に調整
 export const TONGUE_ANGLE_DEGREES = 45;
 export const TONGUE_WIDTH = 5;
 export const TONGUE_CHECK_INTERVAL = 5;
 export const TONGUE_TIP_RADIUS = 10; // 舌の先端の半径（当たり判定と描画用）
 
 // マメ関連
-export const BEAN_BASE_SPEED = 3;
+export const BEAN_BASE_SPEED = 3 / 2; // 1/2に調整
 export const BEAN_MIN_SCORE = 10;
 export const BEAN_MAX_SCORE = 300;
 export const BEAN_FLASH_INTERVAL = 200;

--- a/bird-and-beans/js/config.js
+++ b/bird-and-beans/js/config.js
@@ -3,7 +3,7 @@ export const CANVAS_WIDTH = 800;
 export const CANVAS_HEIGHT = 600;
 
 // プレイヤー関連
-export const PLAYER_SPEED = 3.3;
+export const PLAYER_SPEED = 5;
 export const PLAYER_GROUND_MARGIN = 10;
 export const PLAYER_ANIMATION_INTERVAL = 200; // ミリ秒単位
 export const PLAYER_IMAGE_DEFAULT = 'assets/bird_default.png';
@@ -18,7 +18,7 @@ export const TONGUE_CHECK_INTERVAL = 5;
 export const TONGUE_TIP_RADIUS = 10; // 舌の先端の半径（当たり判定と描画用）
 
 // マメ関連
-export const BEAN_BASE_SPEED = 1.5;
+export const BEAN_BASE_SPEED = 2;
 export const BEAN_MIN_SCORE = 10;
 export const BEAN_MAX_SCORE = 300;
 export const BEAN_FLASH_INTERVAL = 200;

--- a/bird-and-beans/js/config.js
+++ b/bird-and-beans/js/config.js
@@ -3,8 +3,6 @@ export const CANVAS_WIDTH = 800;
 export const CANVAS_HEIGHT = 600;
 
 // プレイヤー関連
-export const PLAYER_WIDTH = 60;
-export const PLAYER_HEIGHT = 60;
 export const PLAYER_SPEED = 10;
 export const PLAYER_GROUND_MARGIN = 10;
 export const PLAYER_ANIMATION_INTERVAL = 200; // ミリ秒単位
@@ -20,8 +18,6 @@ export const TONGUE_CHECK_INTERVAL = 5;
 export const TONGUE_TIP_RADIUS = 10; // 舌の先端の半径（当たり判定と描画用）
 
 // マメ関連
-export const BEAN_WIDTH = 20;
-export const BEAN_HEIGHT = 20;
 export const BEAN_BASE_SPEED = 3;
 export const BEAN_MIN_SCORE = 10;
 export const BEAN_MAX_SCORE = 300;
@@ -96,3 +92,17 @@ export const SCORE_EFFECT_DURATION = 3000; // 3秒間表示
 
 // ローカルストレージ
 export const HIGH_SCORE_KEY = 'birdAndBeansHighScore';
+
+// 動的に計算される値
+export const calculateDimensions = () => {
+  const blockSize = CANVAS_WIDTH / GROUND_BLOCK_COUNT;
+  return {
+    blockSize,
+    blockWidth: blockSize,
+    blockHeight: blockSize,
+    playerWidth: blockSize,
+    playerHeight: blockSize,
+    beanWidth: blockSize * (2 / 3),
+    beanHeight: blockSize * (2 / 3),
+  };
+};

--- a/bird-and-beans/js/config.js
+++ b/bird-and-beans/js/config.js
@@ -3,7 +3,7 @@ export const CANVAS_WIDTH = 800;
 export const CANVAS_HEIGHT = 600;
 
 // プレイヤー関連
-export const PLAYER_SPEED = 10 / 3; // 1/3に調整
+export const PLAYER_SPEED = 3.3;
 export const PLAYER_GROUND_MARGIN = 10;
 export const PLAYER_ANIMATION_INTERVAL = 200; // ミリ秒単位
 export const PLAYER_IMAGE_DEFAULT = 'assets/bird_default.png';
@@ -11,14 +11,14 @@ export const PLAYER_IMAGE_WALK = 'assets/bird_walk.png';
 
 // 舌関連
 export const TONGUE_MAX_LENGTH = 700; // 画面サイズ800x600に合わせて調整
-export const TONGUE_EXTEND_SPEED = 30 / 2; // 1/2に調整
+export const TONGUE_EXTEND_SPEED = 15;
 export const TONGUE_ANGLE_DEGREES = 45;
 export const TONGUE_WIDTH = 5;
 export const TONGUE_CHECK_INTERVAL = 5;
 export const TONGUE_TIP_RADIUS = 10; // 舌の先端の半径（当たり判定と描画用）
 
 // マメ関連
-export const BEAN_BASE_SPEED = 3 / 2; // 1/2に調整
+export const BEAN_BASE_SPEED = 1.5;
 export const BEAN_MIN_SCORE = 10;
 export const BEAN_MAX_SCORE = 300;
 export const BEAN_FLASH_INTERVAL = 200;

--- a/bird-and-beans/js/constants.js
+++ b/bird-and-beans/js/constants.js
@@ -12,7 +12,7 @@ export const PLAYER_IMAGE_DEFAULT = 'assets/bird_default.png';
 export const PLAYER_IMAGE_WALK = 'assets/bird_walk.png';
 
 // 舌関連
-export const TONGUE_MAX_LENGTH = 1000;
+export const TONGUE_MAX_LENGTH = 700; // 画面サイズ800x600に合わせて調整
 export const TONGUE_EXTEND_SPEED = 30;
 export const TONGUE_ANGLE_DEGREES = 45;
 export const TONGUE_WIDTH = 5;

--- a/bird-and-beans/js/constants.js
+++ b/bird-and-beans/js/constants.js
@@ -1,6 +1,6 @@
 // 画面サイズ
-export const CANVAS_WIDTH = 1280;
-export const CANVAS_HEIGHT = 720;
+export const CANVAS_WIDTH = 800;
+export const CANVAS_HEIGHT = 600;
 
 // プレイヤー関連
 export const PLAYER_WIDTH = 60;

--- a/bird-and-beans/js/constants.js
+++ b/bird-and-beans/js/constants.js
@@ -41,21 +41,6 @@ export const BEAN_SPAWN_PROBABILITY = {
   WHITE: 0.15,
 };
 
-// スコアゾーン関連
-// 動的に計算される関数
-export const calculateScoreZones = (canvasWidth, canvasHeight) => {
-  const blockHeight = canvasWidth / GROUND_BLOCK_COUNT;
-  const remainingHeight = canvasHeight - blockHeight * 2;
-  const zoneHeight = remainingHeight / 5;
-
-  return [
-    { maxHeight: blockHeight + zoneHeight, score: 1000 }, // 最上部ゾーン
-    { maxHeight: blockHeight + zoneHeight * 2, score: 300 }, // ゾーン2
-    { maxHeight: blockHeight + zoneHeight * 3, score: 100 }, // ゾーン3
-    { maxHeight: blockHeight + zoneHeight * 4, score: 50 }, // ゾーン4
-    { maxHeight: Infinity, score: 10 }, // ゾーン5（最下部）
-  ];
-};
 
 // 地面関連
 export const GROUND_BLOCK_COUNT = 30;

--- a/bird-and-beans/js/constants.js
+++ b/bird-and-beans/js/constants.js
@@ -42,14 +42,20 @@ export const BEAN_SPAWN_PROBABILITY = {
 };
 
 // スコアゾーン関連
-// 画面高さ720px - 上下40px = 640pxを5分割（各128px）
-export const SCORE_ZONES = [
-  { maxHeight: 168, score: 1000 }, // 最上部ゾーン: 0〜168px (40px + 128px)
-  { maxHeight: 296, score: 300 }, // ゾーン2: 168〜296px (128px幅)
-  { maxHeight: 424, score: 100 }, // ゾーン3: 296〜424px (128px幅)
-  { maxHeight: 552, score: 50 }, // ゾーン4: 424〜552px (128px幅)
-  { maxHeight: Infinity, score: 10 }, // ゾーン5: 552px〜 (128px + 40px)
-];
+// 動的に計算される関数
+export const calculateScoreZones = (canvasWidth, canvasHeight) => {
+  const blockHeight = canvasWidth / GROUND_BLOCK_COUNT;
+  const remainingHeight = canvasHeight - blockHeight * 2;
+  const zoneHeight = remainingHeight / 5;
+
+  return [
+    { maxHeight: blockHeight + zoneHeight, score: 1000 }, // 最上部ゾーン
+    { maxHeight: blockHeight + zoneHeight * 2, score: 300 }, // ゾーン2
+    { maxHeight: blockHeight + zoneHeight * 3, score: 100 }, // ゾーン3
+    { maxHeight: blockHeight + zoneHeight * 4, score: 50 }, // ゾーン4
+    { maxHeight: Infinity, score: 10 }, // ゾーン5（最下部）
+  ];
+};
 
 // 地面関連
 export const GROUND_BLOCK_COUNT = 30;

--- a/bird-and-beans/js/constants.js
+++ b/bird-and-beans/js/constants.js
@@ -41,7 +41,6 @@ export const BEAN_SPAWN_PROBABILITY = {
   WHITE: 0.15,
 };
 
-
 // 地面関連
 export const GROUND_BLOCK_COUNT = 30;
 export const GROUND_BLOCK_IMAGE = 'assets/floor-block.png';

--- a/bird-and-beans/js/game.js
+++ b/bird-and-beans/js/game.js
@@ -5,7 +5,7 @@ import { BeanManager } from './bean.js';
 import { Ground } from './ground.js';
 import { AudioManager } from './audio.js';
 import { ScoreEffectManager } from './scoreEffect.js';
-import { HIGH_SCORE_KEY } from './constants.js';
+import { HIGH_SCORE_KEY } from './config.js';
 
 export class Game {
   constructor(canvas, ctx) {

--- a/bird-and-beans/js/ground.js
+++ b/bird-and-beans/js/ground.js
@@ -1,4 +1,4 @@
-import { GROUND_BLOCK_COUNT, GROUND_BLOCK_IMAGE, COLORS } from './constants.js';
+import { GROUND_BLOCK_COUNT, GROUND_BLOCK_IMAGE, COLORS } from './config.js';
 import { CollisionManager } from './collision.js';
 
 export class Ground {

--- a/bird-and-beans/js/main.js
+++ b/bird-and-beans/js/main.js
@@ -1,5 +1,5 @@
 import { Game } from './game.js';
-import { CANVAS_WIDTH, CANVAS_HEIGHT } from './constants.js';
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from './config.js';
 
 let game;
 

--- a/bird-and-beans/js/player.js
+++ b/bird-and-beans/js/player.js
@@ -1,10 +1,9 @@
 import {
-  PLAYER_WIDTH,
-  PLAYER_HEIGHT,
   PLAYER_SPEED,
   PLAYER_ANIMATION_INTERVAL,
   PLAYER_IMAGE_DEFAULT,
   PLAYER_IMAGE_WALK,
+  GROUND_BLOCK_COUNT,
 } from './constants.js';
 import { Tongue } from './tongue.js';
 import { CollisionManager } from './collision.js';
@@ -19,8 +18,10 @@ export class Player {
     this.canvasWidth = canvasWidth;
     this.canvasHeight = canvasHeight;
 
-    this.width = PLAYER_WIDTH;
-    this.height = PLAYER_HEIGHT;
+    // ブロックサイズと同じサイズに設定
+    const blockSize = canvasWidth / GROUND_BLOCK_COUNT;
+    this.width = blockSize;
+    this.height = blockSize;
     this.x = canvasWidth / 2 - this.width / 2;
     // Y座標は後でsetGroundPositionで設定される
     this.y = 0;

--- a/bird-and-beans/js/player.js
+++ b/bird-and-beans/js/player.js
@@ -3,8 +3,8 @@ import {
   PLAYER_ANIMATION_INTERVAL,
   PLAYER_IMAGE_DEFAULT,
   PLAYER_IMAGE_WALK,
-  GROUND_BLOCK_COUNT,
-} from './constants.js';
+  calculateDimensions,
+} from './config.js';
 import { Tongue } from './tongue.js';
 import { CollisionManager } from './collision.js';
 
@@ -19,9 +19,9 @@ export class Player {
     this.canvasHeight = canvasHeight;
 
     // ブロックサイズと同じサイズに設定
-    const blockSize = canvasWidth / GROUND_BLOCK_COUNT;
-    this.width = blockSize;
-    this.height = blockSize;
+    const dimensions = calculateDimensions();
+    this.width = dimensions.playerWidth;
+    this.height = dimensions.playerHeight;
     this.x = canvasWidth / 2 - this.width / 2;
     // Y座標は後でsetGroundPositionで設定される
     this.y = 0;

--- a/bird-and-beans/js/render.js
+++ b/bird-and-beans/js/render.js
@@ -1,4 +1,4 @@
-import { COLORS } from './constants.js';
+import { COLORS } from './config.js';
 
 export class Renderer {
   constructor(ctx) {

--- a/bird-and-beans/js/scoreEffect.js
+++ b/bird-and-beans/js/scoreEffect.js
@@ -1,4 +1,4 @@
-import { COLORS, FONTS, SCORE_EFFECT_DURATION } from './constants.js';
+import { COLORS, FONTS, SCORE_EFFECT_DURATION } from './config.js';
 
 export class ScoreEffect {
   constructor(x, y, score) {

--- a/bird-and-beans/js/tongue.js
+++ b/bird-and-beans/js/tongue.js
@@ -5,7 +5,7 @@ import {
   TONGUE_WIDTH,
   TONGUE_TIP_RADIUS,
   COLORS,
-} from './constants.js';
+} from './config.js';
 import { CollisionManager } from './collision.js';
 
 export class Tongue {


### PR DESCRIPTION
## Summary
- 画面サイズを800x600に変更
- スコアゾーン、プレイヤー、マメのサイズを動的に計算する機能を実装
- ゲームバランス調整（各種速度の変更）

## 変更内容
### 画面サイズ関連
- キャンバスサイズを1280x720から800x600に変更
- index.htmlのcanvas要素のサイズも更新
- 舌の最大長を700pxに調整

### 動的サイズ計算
- `constants.js`を`config.js`にリネーム
- `calculateDimensions()`関数を追加し、以下を動的に計算：
  - プレイヤーサイズ = ブロックサイズ
  - マメサイズ = ブロックサイズの2/3
  - スコアゾーンも画面サイズに応じて自動調整

### ゲームバランス調整
- プレイヤーの移動速度: 10 → 5
- マメの落下速度: 3 → 2
- 舌が伸びる速度: 30 → 15

## Test plan
- [ ] ゲームが正常に起動する
- [ ] 画面サイズが800x600で表示される
- [ ] プレイヤーとマメのサイズが適切に表示される
- [ ] ゲームプレイが適切な速度で動作する
- [ ] スコアゾーンが正しく機能する

🤖 Generated with [Claude Code](https://claude.ai/code)