### PR TITLE
feat: Press Start 2Pフォントを適用してゲームらしい見た目に変更

### DIFF
--- a/bird-and-beans/css/style.css
+++ b/bird-and-beans/css/style.css
@@ -5,7 +5,7 @@
 }
 
 body {
-  font-family: 'Arial', sans-serif;
+  font-family: 'Press Start 2P', 'Arial', sans-serif;
   background-color: #0a0a0a;
   color: #ffffff;
   display: flex;
@@ -27,7 +27,7 @@ body {
   display: flex;
   justify-content: space-between;
   margin-bottom: 20px;
-  font-size: 24px;
+  font-size: 12px;
 }
 
 .score-container,
@@ -38,13 +38,13 @@ body {
 }
 
 .score-label {
-  font-size: 16px;
+  font-size: 10px;
   color: #888;
   margin-bottom: 5px;
 }
 
 .score-value {
-  font-size: 28px;
+  font-size: 16px;
   font-weight: bold;
   color: #fff;
 }
@@ -70,19 +70,19 @@ body {
 }
 
 .game-over h2 {
-  font-size: 36px;
+  font-size: 18px;
   margin-bottom: 20px;
   color: #ff6b6b;
 }
 
 .game-over p {
-  font-size: 24px;
+  font-size: 14px;
   margin-bottom: 30px;
 }
 
 #restart-button {
   padding: 15px 30px;
-  font-size: 20px;
+  font-size: 12px;
   background-color: #4ecdc4;
   color: #fff;
   border: none;

--- a/bird-and-beans/index.html
+++ b/bird-and-beans/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>鳥とマメ - Bird & Beans</title>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>

--- a/bird-and-beans/js/config.js
+++ b/bird-and-beans/js/config.js
@@ -84,7 +84,7 @@ export const AUDIO_TYPES = {
 
 // フォント
 export const FONTS = {
-  SCORE_EFFECT: '20px Arial',
+  SCORE_EFFECT: '16px "Press Start 2P"',
 };
 
 // スコアエフェクト関連


### PR DESCRIPTION
Issue #18 に対応して、ゲームらしいドットフォント「Press Start 2P」を適用しました。

## 変更内容
- Google Fontsから Press Start 2P を読み込み
- スコアエフェクトのフォントを16pxのPress Start 2Pに変更
- UI全体（スコア表示、ゲームオーバー画面）も同じフォントに統一
- ピクセルフォントに合わせてフォントサイズを調整

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * アプリ全体のフォントが「Press Start 2P」に変更され、ピクセル風のデザインになりました。
  * 各UI要素（ヘッダー、スコア表示、ゲームオーバー画面など）のフォントサイズが小さくなりました。
  * スコアエフェクトのフォントも新しいデザインに統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->